### PR TITLE
GHA: Enable on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.json text eol=lf

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         nim: ['devel', 'version-1-4']
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Prevent the auto LF -> CRLF conversion for the test JSON files.

Fixes https://github.com/kaushalmodi/p4ztag_to_json/issues/3.